### PR TITLE
feat: add 'Create .md file' button in issue/PR detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the **OrbiTrack** IntelliJ plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] — 2026-04-03
+
+### Added
+
+- **"Create .md file" button** in the issue/PR detail action bar — generates a structured Markdown file (`{type}-{org}-{repo}-{number}.md`) in the project root containing the full title, metadata (repo, state, labels, author, assignees, milestone, URL, dates), body, and all currently cached comments; silently overwrites any existing file and immediately opens it in the IDE editor
+
 ## [1.0.2] — 2026-03-26
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=dev.anvas.orbitrack.idea
 pluginName=OrbiTrack
-pluginVersion=1.0.2
+pluginVersion=1.0.3
 pluginSinceBuild=251
 pluginUntilBuild=261.*
 

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/ItemDetailPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/ItemDetailPanel.kt
@@ -37,6 +37,9 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
     /** Callback when user wants to refresh this single item. Receives (item). */
     var onRefreshItem: ((OrbiItem) -> Unit)? = null
 
+    /** Callback when user wants to export issue/PR as a .md file. Receives (item, comments). */
+    var onCreateMdFile: ((OrbiItem, List<OrbiComment>) -> Unit)? = null
+
     private var currentItem: OrbiItem? = null
     private var isItemLoading: Boolean = false
 
@@ -293,6 +296,10 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
             })
             add(JButton("Copy LLM Context").apply {
                 addActionListener { copyContext(item, comments) }
+            })
+            add(JButton("\uD83D\uDCC4 Create .md file").apply {
+                toolTipText = "Save issue/PR as a Markdown file in the project root"
+                addActionListener { onCreateMdFile?.invoke(item, comments) }
             })
         }
 

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/OrbiTrackPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/OrbiTrackPanel.kt
@@ -5,15 +5,22 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
 import dev.anvas.orbitrack.idea.model.ItemType
+import dev.anvas.orbitrack.idea.model.OrbiComment
 import dev.anvas.orbitrack.idea.model.OrbiItem
 import dev.anvas.orbitrack.idea.services.OrbiTrackProjectService
 import java.awt.BorderLayout
+import java.io.File
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import javax.swing.*
 
 class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Disposable {
@@ -125,6 +132,32 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
                                 "OrbiTrack",
                                 JOptionPane.ERROR_MESSAGE
                             )
+                        }
+                    }
+                }
+            }
+        }
+        onCreateMdFile = { item, comments ->
+            val basePath = project.basePath
+            if (basePath == null) {
+                JOptionPane.showMessageDialog(
+                    this@OrbiTrackPanel,
+                    "Cannot determine project base path.",
+                    "OrbiTrack",
+                    JOptionPane.ERROR_MESSAGE
+                )
+            } else {
+                val typeStr = item.type.name.lowercase()
+                val filename = "$typeStr-${item.org}-${item.repo}-${item.number}.md"
+                val targetFile = File(basePath, filename)
+                val content = buildMdFileContent(item, comments)
+
+                WriteCommandAction.runWriteCommandAction(project) {
+                    targetFile.writeText(content)
+                    val vFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(targetFile)
+                    if (vFile != null) {
+                        ApplicationManager.getApplication().invokeLater {
+                            FileEditorManager.getInstance(project).openFile(vFile, true)
                         }
                     }
                 }
@@ -326,6 +359,45 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
             result.addAll(buildGrouped(group, rest, depth + 1))
         }
         return result
+    }
+
+    private fun buildMdFileContent(item: OrbiItem, comments: List<OrbiComment>): String {
+        val dateFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+            .withZone(ZoneId.systemDefault())
+        val typeStr = if (item.type == ItemType.PR) "PR" else "Issue"
+        return buildString {
+            appendLine("# $typeStr #${item.number}: ${item.title}")
+            appendLine()
+            appendLine("**Repo:** ${item.org}/${item.repo}")
+            appendLine("**State:** ${item.state.name.lowercase()}")
+            appendLine("**Labels:** ${item.labels.joinToString().ifEmpty { "—" }}")
+            appendLine("**Author:** @${item.author}")
+            if (item.assignees.isNotEmpty()) {
+                appendLine("**Assignees:** ${item.assignees.joinToString { "@$it" }}")
+            }
+            item.milestone?.let { appendLine("**Milestone:** $it") }
+            appendLine("**URL:** ${item.url}")
+            appendLine("**Opened:** ${dateFmt.format(item.createdAt)}")
+            appendLine("**Updated:** ${dateFmt.format(item.updatedAt)}")
+            appendLine()
+            appendLine("---")
+            appendLine()
+            appendLine("## Description")
+            appendLine()
+            appendLine(item.body.ifBlank { "*(no description)*" })
+            if (comments.isNotEmpty()) {
+                appendLine()
+                appendLine("---")
+                appendLine()
+                appendLine("## Comments (${comments.size})")
+                for (c in comments) {
+                    appendLine()
+                    appendLine("### @${c.author} · ${dateFmt.format(c.createdAt)}")
+                    appendLine()
+                    appendLine(c.body)
+                }
+            }
+        }
     }
 
     override fun dispose() {


### PR DESCRIPTION
Closes #13

## What

Adds a **"📄 Create .md file"** button to the action bar in the issue/PR detail panel, alongside the existing "Copy LLM Context" button.

## How it works

1. User selects an issue or PR in the list.
2. Clicks **"Create .md file"** in the detail action bar.
3. A Markdown file is written to the project root:
   - **Filename**: `{type}-{org}-{repo}-{number}.md`
     e.g. `issue-myorg-backend-42.md` / `pr-myorg-frontend-7.md`
   - **Content**: title, repo/state/labels/author/assignees/milestone/URL/dates, full body, then all currently cached comments (with per-comment author + timestamp headers)
4. Any existing file at that path is silently overwritten.
5. The file is immediately opened as a focused tab in the IDE editor via `FileEditorManager`.

## Files changed

| File | Change |
|------|--------|
| `ItemDetailPanel.kt` | Add `onCreateMdFile` callback; add button in action bar |
| `OrbiTrackPanel.kt` | Wire callback, `buildMdFileContent()` helper, VFS write + editor open |
| `gradle.properties` | `pluginVersion` → `1.0.3` |
| `CHANGELOG.md` | Add `[1.0.3]` entry |

