### PR TITLE
feat: collapsible filter panel with active-filter summary (v1.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the **OrbiTrack** IntelliJ plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] — 2026-04-04
+
+### Added
+
+- **Collapsible filter panel** — a full-width toggle button (`▾ Filters` / `▸ Filters`) now sits at the top of the filter sidebar; clicking it collapses or expands all filter controls, freeing vertical space for the issues list
+- **Active-filter summary in collapsed header** — when the panel is collapsed, any non-default selections (state, type, repo/org, sort) are summarised inline in the toggle button label (e.g. `▸ Filters · Closed · PRs · my-org/my-repo`), capped at 40 characters
+- **Collapse state persistence** — the expanded/collapsed preference is stored in `CachedFilterState.filtersCollapsed` and restored automatically on IDE restart; existing cache files without the field default to expanded (backward-compatible)
+
 ## [1.0.3] — 2026-04-03
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=dev.anvas.orbitrack.idea
 pluginName=OrbiTrack
-pluginVersion=1.0.3
+pluginVersion=1.0.4
 pluginSinceBuild=251
 pluginUntilBuild=261.*
 

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/cache/OrbiCacheManager.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/cache/OrbiCacheManager.kt
@@ -129,6 +129,7 @@ data class CachedFilterState(
     val sortField: String = "UPDATED",
     val sortDirection: String = "DESC",
     val groupModes: List<String> = listOf("BY_TYPE"),
+    val filtersCollapsed: Boolean = false,
 )
 
 @Serializable

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/FilterPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/FilterPanel.kt
@@ -66,8 +66,26 @@ class FilterPanel(
     val groupModes: List<GroupMode>
         get() = GroupMode.entries.filter { groupChecks[it]?.isSelected == true }
 
+    // --- Collapsible inner panel ---
+    private val innerPanel = JPanel(GridBagLayout()).apply {
+        isOpaque = false
+    }
+
+    /** Full-width toggle button at the top of the panel. */
+    private val toggleButton = JButton().apply {
+        isOpaque = false
+        isFocusPainted = false
+        horizontalAlignment = SwingConstants.LEFT
+        border = JBUI.Borders.empty(2, 0, 2, 0)
+        addActionListener {
+            innerPanel.isVisible = !innerPanel.isVisible
+            updateToggleButtonLabel()
+            if (!suppressEvents) onFilterChanged()
+        }
+    }
+
     init {
-        border = JBUI.Borders.empty(6, 8, 2, 8)
+        border = JBUI.Borders.empty(4, 8, 2, 8)
         isOpaque = false
 
         val labelInsets = Insets(2, 0, 0, 4)
@@ -75,11 +93,11 @@ class FilterPanel(
 
         var row = 0
         fun addRow(label: String, component: JComponent) {
-            add(JBLabel("$label:"), GridBagConstraints().apply {
+            innerPanel.add(JBLabel("$label:"), GridBagConstraints().apply {
                 gridx = 0; gridy = row; anchor = GridBagConstraints.WEST; insets = labelInsets
             })
             row++
-            add(component, GridBagConstraints().apply {
+            innerPanel.add(component, GridBagConstraints().apply {
                 gridx = 0; gridy = row; fill = GridBagConstraints.HORIZONTAL
                 weightx = 1.0; insets = comboInsets
             })
@@ -93,20 +111,77 @@ class FilterPanel(
         addRow("Sort", sortPanel)
         addRow("View", groupButton)
 
-        orgCombo.addActionListener { if (!suppressEvents) onFilterChanged() }
-        repoCombo.addActionListener { if (!suppressEvents) onFilterChanged() }
-        typeCombo.addActionListener { if (!suppressEvents) onFilterChanged() }
-        stateCombo.addActionListener { if (!suppressEvents) onFilterChanged() }
-        sortFieldCombo.addActionListener { if (!suppressEvents) onFilterChanged() }
+        orgCombo.addActionListener { if (!suppressEvents) { updateToggleButtonLabel(); onFilterChanged() } }
+        repoCombo.addActionListener { if (!suppressEvents) { updateToggleButtonLabel(); onFilterChanged() } }
+        typeCombo.addActionListener { if (!suppressEvents) { updateToggleButtonLabel(); onFilterChanged() } }
+        stateCombo.addActionListener { if (!suppressEvents) { updateToggleButtonLabel(); onFilterChanged() } }
+        sortFieldCombo.addActionListener { if (!suppressEvents) { updateToggleButtonLabel(); onFilterChanged() } }
         for ((_, checkItem) in groupChecks) {
             checkItem.addActionListener {
                 updateGroupButtonLabel()
+                updateToggleButtonLabel()
                 if (!suppressEvents) onFilterChanged()
             }
         }
 
         // Reflect default grouping selection in button label
         updateGroupButtonLabel()
+
+        // Layout: toggle button at top, collapsible inner panel below
+        add(toggleButton, GridBagConstraints().apply {
+            gridx = 0; gridy = 0; fill = GridBagConstraints.HORIZONTAL; weightx = 1.0
+            insets = Insets(0, 0, 4, 0)
+        })
+        add(innerPanel, GridBagConstraints().apply {
+            gridx = 0; gridy = 1; fill = GridBagConstraints.HORIZONTAL; weightx = 1.0
+        })
+
+        updateToggleButtonLabel()
+    }
+
+    // --- Summary helpers ---
+
+    /**
+     * Builds a compact string of non-default active filter selections,
+     * e.g. "Closed · PRs · my-org" — capped at 40 chars with ellipsis.
+     */
+    internal fun buildSummary(): String {
+        val parts = mutableListOf<String>()
+
+        // State (default = index 0 "Open")
+        if (stateCombo.selectedIndex != 0) {
+            parts += stateCombo.selectedItem?.toString() ?: ""
+        }
+        // Type (default = index 0 "All Types")
+        if (typeCombo.selectedIndex != 0) {
+            parts += typeCombo.selectedItem?.toString() ?: ""
+        }
+        // Repo (default = index 0 "All Repos")  — more specific than org, show first
+        if (repoCombo.selectedIndex != 0) {
+            parts += repoCombo.selectedItem?.toString() ?: ""
+        } else if (orgCombo.selectedIndex != 0) {
+            // Org (default = index 0 "All Orgs")
+            parts += orgCombo.selectedItem?.toString() ?: ""
+        }
+        // Sort — show when not default (UPDATED DESC)
+        val currentField = sortFieldCombo.selectedItem as? SortField ?: SortField.UPDATED
+        if (currentField != SortField.UPDATED || sortDirection != SortDirection.DESC) {
+            parts += "${currentField.name.lowercase()} ${sortDirection.symbol}"
+        }
+
+        if (parts.isEmpty()) return ""
+
+        val joined = parts.filter { it.isNotBlank() }.joinToString(" \u00B7 ")
+        return if (joined.length > 40) joined.take(39) + "\u2026" else joined
+    }
+
+    private fun updateToggleButtonLabel() {
+        val summary = buildSummary()
+        toggleButton.text = if (innerPanel.isVisible) {
+            "\u25BE Filters"
+        } else {
+            if (summary.isBlank()) "\u25B8 Filters" else "\u25B8 Filters \u00B7 $summary"
+        }
     }
 
     private fun updateGroupButtonLabel() {
@@ -136,6 +211,7 @@ class FilterPanel(
         } finally {
             suppressEvents = false
         }
+        updateToggleButtonLabel()
     }
 
     fun applyFilter(items: List<OrbiItem>): List<OrbiItem> {
@@ -172,7 +248,7 @@ class FilterPanel(
         }
     }
 
-    /** Captures the current filter/sort/group state for persistence. */
+    /** Captures the current filter/sort/group/collapse state for persistence. */
     fun getFilterState(): CachedFilterState {
         return CachedFilterState(
             selectedOrg = if (orgCombo.selectedIndex > 0) orgCombo.selectedItem as? String else null,
@@ -182,10 +258,11 @@ class FilterPanel(
             sortField = (sortFieldCombo.selectedItem as? SortField)?.name ?: "UPDATED",
             sortDirection = sortDirection.name,
             groupModes = groupModes.map { it.name },
+            filtersCollapsed = !innerPanel.isVisible,
         )
     }
 
-    /** Restores filter/sort/group state from a cached snapshot. */
+    /** Restores filter/sort/group/collapse state from a cached snapshot. */
     fun restoreFilterState(state: CachedFilterState) {
         suppressEvents = true
         try {
@@ -218,8 +295,12 @@ class FilterPanel(
                 checkItem.isSelected = mode in restoredModes
             }
             updateGroupButtonLabel()
+
+            // Collapse state
+            innerPanel.isVisible = !state.filtersCollapsed
         } finally {
             suppressEvents = false
         }
+        updateToggleButtonLabel()
     }
 }

--- a/src/test/kotlin/dev/anvas/orbitrack/idea/CachedFilterStateTest.kt
+++ b/src/test/kotlin/dev/anvas/orbitrack/idea/CachedFilterStateTest.kt
@@ -1,0 +1,81 @@
+package dev.anvas.orbitrack.idea
+
+import dev.anvas.orbitrack.idea.cache.CachedFilterState
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [CachedFilterState] — no IntelliJ Platform required.
+ */
+class CachedFilterStateTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `filtersCollapsed defaults to false`() {
+        val state = CachedFilterState()
+        assertFalse("filtersCollapsed should default to false", state.filtersCollapsed)
+    }
+
+    @Test
+    fun `filtersCollapsed can be set to true`() {
+        val state = CachedFilterState(filtersCollapsed = true)
+        assertTrue(state.filtersCollapsed)
+    }
+
+    @Test
+    fun `copy preserves filtersCollapsed`() {
+        val original = CachedFilterState(typeIndex = 1, filtersCollapsed = true)
+        val copied = original.copy(stateIndex = 2)
+        assertTrue("copy should preserve filtersCollapsed", copied.filtersCollapsed)
+        assertEquals(1, copied.typeIndex)
+        assertEquals(2, copied.stateIndex)
+    }
+
+    @Test
+    fun `serialization includes filtersCollapsed when true`() {
+        val state = CachedFilterState(filtersCollapsed = true)
+        val serialized = json.encodeToString(CachedFilterState.serializer(), state)
+        assertTrue("Serialized JSON must contain filtersCollapsed", serialized.contains("filtersCollapsed"))
+        assertTrue("filtersCollapsed must be true in JSON", serialized.contains("\"filtersCollapsed\":true"))
+    }
+
+    @Test
+    fun `deserialization restores filtersCollapsed true`() {
+        val raw = """{"filtersCollapsed":true,"sortField":"UPDATED","sortDirection":"DESC","groupModes":["BY_TYPE"]}"""
+        val state = json.decodeFromString<CachedFilterState>(raw)
+        assertTrue(state.filtersCollapsed)
+    }
+
+    @Test
+    fun `deserialization defaults filtersCollapsed to false when field absent`() {
+        // Simulates an old cache file that predates the field
+        val raw = """{"sortField":"UPDATED","sortDirection":"DESC","groupModes":["BY_TYPE"]}"""
+        val state = json.decodeFromString<CachedFilterState>(raw)
+        assertFalse("Missing field must default to false", state.filtersCollapsed)
+    }
+
+    @Test
+    fun `round-trip serialization preserves all fields`() {
+        val original = CachedFilterState(
+            selectedOrg = "my-org",
+            selectedRepo = "my-org/my-repo",
+            typeIndex = 2,
+            stateIndex = 1,
+            sortField = "CREATED",
+            sortDirection = "ASC",
+            groupModes = listOf("BY_ORG", "BY_REPO"),
+            filtersCollapsed = true,
+        )
+        val serialized = json.encodeToString(CachedFilterState.serializer(), original)
+        val restored = json.decodeFromString<CachedFilterState>(serialized)
+        assertEquals(original, restored)
+    }
+}
+

--- a/src/test/kotlin/dev/anvas/orbitrack/idea/FilterPanelCollapseTest.kt
+++ b/src/test/kotlin/dev/anvas/orbitrack/idea/FilterPanelCollapseTest.kt
@@ -1,0 +1,194 @@
+package dev.anvas.orbitrack.idea
+
+import dev.anvas.orbitrack.idea.cache.CachedFilterState
+import dev.anvas.orbitrack.idea.ui.FilterPanel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+import java.lang.reflect.Field
+
+/**
+ * Tests for [FilterPanel]'s collapsible header behaviour.
+ *
+ * These tests rely on headless AWT.  If AWT is unavailable (e.g. in a fully
+ * display-less CI without `java.awt.headless=true`) the test is skipped via
+ * [Assume] rather than failing the build.
+ */
+class FilterPanelCollapseTest {
+
+    @Before
+    fun requireHeadless() {
+        System.setProperty("java.awt.headless", "true")
+    }
+
+    // ---------- helpers ----------
+
+    /**
+     * Creates a [FilterPanel] and ensures it was constructed without errors.
+     * Returns the panel or skips the test if the AWT environment is unavailable.
+     */
+    private fun makePanel(): FilterPanel {
+        return try {
+            FilterPanel {}
+        } catch (e: Exception) {
+            Assume.assumeNoException("Skipping: cannot construct FilterPanel in this environment", e)
+            throw e // unreachable – Assume throws AssumptionViolatedException
+        }
+    }
+
+    /** Reads a private field from [FilterPanel] by name via reflection. */
+    private fun readField(panel: FilterPanel, name: String): Any? {
+        var cls: Class<*>? = panel.javaClass
+        while (cls != null) {
+            try {
+                val f: Field = cls.getDeclaredField(name)
+                f.isAccessible = true
+                return f.get(panel)
+            } catch (_: NoSuchFieldException) {
+                cls = cls.superclass
+            }
+        }
+        error("Field '$name' not found in FilterPanel hierarchy")
+    }
+
+    private fun innerPanelVisible(panel: FilterPanel): Boolean {
+        val inner = readField(panel, "innerPanel") as javax.swing.JPanel
+        return inner.isVisible
+    }
+
+    // ---------- tests ----------
+
+    @Test
+    fun `default state is expanded`() {
+        val panel = makePanel()
+        assertTrue("Filter controls must be visible by default", innerPanelVisible(panel))
+    }
+
+    @Test
+    fun `getFilterState reports filtersCollapsed false when expanded`() {
+        val panel = makePanel()
+        assertFalse(panel.getFilterState().filtersCollapsed)
+    }
+
+    @Test
+    fun `clicking toggle hides inner panel`() {
+        val panel = makePanel()
+        val toggleButton = readField(panel, "toggleButton") as javax.swing.JButton
+        // simulate click
+        toggleButton.doClick()
+        assertFalse("Inner panel must be hidden after toggle", innerPanelVisible(panel))
+    }
+
+    @Test
+    fun `getFilterState reports filtersCollapsed true after toggle`() {
+        val panel = makePanel()
+        val toggleButton = readField(panel, "toggleButton") as javax.swing.JButton
+        toggleButton.doClick()
+        assertTrue(panel.getFilterState().filtersCollapsed)
+    }
+
+    @Test
+    fun `toggle twice returns to expanded`() {
+        val panel = makePanel()
+        val toggleButton = readField(panel, "toggleButton") as javax.swing.JButton
+        toggleButton.doClick()
+        toggleButton.doClick()
+        assertTrue("Inner panel must be visible after two toggles", innerPanelVisible(panel))
+        assertFalse(panel.getFilterState().filtersCollapsed)
+    }
+
+    @Test
+    fun `restoreFilterState with filtersCollapsed true hides inner panel`() {
+        val panel = makePanel()
+        val state = CachedFilterState(filtersCollapsed = true)
+        panel.restoreFilterState(state)
+        assertFalse("Inner panel must be hidden after restoring collapsed state", innerPanelVisible(panel))
+    }
+
+    @Test
+    fun `restoreFilterState with filtersCollapsed false keeps inner panel visible`() {
+        val panel = makePanel()
+        // First collapse it so we know restore actually changes things
+        val collapsedState = CachedFilterState(filtersCollapsed = true)
+        panel.restoreFilterState(collapsedState)
+        val expandedState = CachedFilterState(filtersCollapsed = false)
+        panel.restoreFilterState(expandedState)
+        assertTrue("Inner panel must be visible after restoring expanded state", innerPanelVisible(panel))
+    }
+
+    @Test
+    fun `toggle button text contains chevron-down when expanded`() {
+        val panel = makePanel()
+        val toggleButton = readField(panel, "toggleButton") as javax.swing.JButton
+        assertTrue(
+            "Expanded toggle must contain ▾ (U+25BE)",
+            toggleButton.text.contains("\u25BE")
+        )
+    }
+
+    @Test
+    fun `toggle button text contains chevron-right when collapsed`() {
+        val panel = makePanel()
+        val toggleButton = readField(panel, "toggleButton") as javax.swing.JButton
+        toggleButton.doClick()
+        assertTrue(
+            "Collapsed toggle must contain ▸ (U+25B8)",
+            toggleButton.text.contains("\u25B8")
+        )
+    }
+
+    @Test
+    fun `buildSummary returns empty string when all defaults`() {
+        val panel = makePanel()
+        val summary = panel.buildSummary()
+        assertTrue("Summary must be blank when all filters are default", summary.isBlank())
+    }
+
+    @Test
+    fun `buildSummary includes state when non-default`() {
+        val panel = makePanel()
+        // stateCombo index 2 = "Closed"
+        val stateCombo = readField(panel, "stateCombo") as javax.swing.JComboBox<*>
+        stateCombo.selectedIndex = 2
+        val summary = panel.buildSummary()
+        assertTrue("Summary must include state selection", summary.contains("Closed"))
+    }
+
+    @Test
+    fun `buildSummary includes type when non-default`() {
+        val panel = makePanel()
+        val typeCombo = readField(panel, "typeCombo") as javax.swing.JComboBox<*>
+        typeCombo.selectedIndex = 2  // "PRs"
+        val summary = panel.buildSummary()
+        assertTrue("Summary must include type selection", summary.contains("PR"))
+    }
+
+    @Test
+    fun `buildSummary is capped at 40 characters`() {
+        val panel = makePanel()
+        // A very long sort field description won't exceed 40 chars alone, but
+        // the join of multiple active filters must still be capped.
+        val summary = panel.buildSummary()
+        assertTrue(
+            "Summary must not exceed 40 chars",
+            summary.length <= 40
+        )
+    }
+
+    @Test
+    fun `collapsed toggle label includes summary when non-default state selected`() {
+        val panel = makePanel()
+        val stateCombo = readField(panel, "stateCombo") as javax.swing.JComboBox<*>
+        stateCombo.selectedIndex = 2  // "Closed"
+        val toggleButton = readField(panel, "toggleButton") as javax.swing.JButton
+        toggleButton.doClick()  // collapse
+        assertTrue(
+            "Collapsed label must show active filter summary",
+            toggleButton.text.contains("Closed")
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary

Resolves #15

Adds a collapsible filter panel to the OrbiTrack sidebar. The filter controls now sit behind a full-width toggle button, so users can collapse them when they need more vertical space to see the issues list.

## Changes

### `FilterPanel.kt`
- All 6 filter rows (Org, Repo, Type, State, Sort, View) moved into a collapsible `innerPanel`
- Full-width `toggleButton` added at the top of the panel:
  - Expanded: `▾ Filters`
  - Collapsed: `▸ Filters · <summary>` — non-default selections summarised inline, capped at 40 chars with ellipsis (e.g. `▸ Filters · Closed · PRs · my-org/repo`)
- `buildSummary()` helper computes the active-filter hint
- `getFilterState()` includes `filtersCollapsed` in the persisted snapshot
- `restoreFilterState()` restores the collapsed/expanded state on IDE restart

### `OrbiCacheManager.kt`
- `CachedFilterState` gains `filtersCollapsed: Boolean = false` — backward-compatible with existing cache files (field defaults to `false` when absent)

### Tests
- `CachedFilterStateTest` (7 tests) — serialization round-trip, default value, backward-compat deserialization
- `FilterPanelCollapseTest` (14 tests) — toggle behaviour, `getFilterState`/`restoreFilterState` round-trip, `buildSummary` output, button label strings

### Other
- `gradle.properties`: `pluginVersion` 1.0.3 → 1.0.4
- `CHANGELOG.md`: `[1.0.4]` entry added

## Test results

```
CachedFilterStateTest   7 tests   0 failures   0 skipped
FilterPanelCollapseTest 14 tests  0 failures   0 skipped
SmokeTest               1 test    0 failures   0 skipped
```

