### PR TITLE
feat: PR review comment history with code suggestions via gh CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to the **OrbiTrack** IntelliJ plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.4] — 2026-04-04
+## [1.0.5] — 2026-04-04
+
+### Added
+
+- **PR inline review comments** — selecting a Pull Request now loads a **Code Review** section below the regular Comments, showing all inline code-annotation comments from the "Files changed" tab; comments are grouped by file path, each card displays the surrounding diff hunk in a monospace block, and code-suggestion comments (`suggestion` fence) are highlighted with a purple border and badge
+- **Lazy "Load all review comments" button** — the first load fetches the initial 30 review comments; when more exist a button appears to fetch all remaining pages at once via `gh api --paginate`
+- **Reply to review thread** — every review comment card has a **↩ Reply** button (plain text) and a **💡 Suggest** button that pre-fills the reply dialog with a `suggestion` code block quoting the last changed line from the diff hunk; replies are posted via `gh api -X POST -F in_reply_to=<id>` and the section refreshes automatically
+- **Review comments in `.md` export** — "Create .md file" now appends a `## Code Review` section to the exported Markdown file, grouped by file path with `diff`-fenced diff hunks, line numbers, and suggestion/reply indicators
+- **Review comments in "Copy LLM Context"** — the clipboard context now includes a `### Code Review Comments` section with the same structure, giving LLMs full diff context for code-review discussions
+- `GhReviewComment` serializable DTO and `OrbiReviewComment` domain model (`path`, `line`, `diffHunk`, `isSuggestion`, `inReplyToId`, `reviewId`)
+- `GhJsonUtils.kt` — `normaliseGhPaginatedJson()` helper that collapses multi-page `gh api --paginate` output (concatenated JSON arrays) into a single valid array before deserialization
+- `runGhCommand()` utility in `OrbiTrackProjectService` (mirrors the existing `runGitCommand` pattern)
+
+### Fixed
+
+- Removed a stray `/**` block-comment opener that had accidentally been left in `OrbiTrackProjectService`, which would have silently swallowed the `checkoutBranch`, `runGitCommand`, `runGhCommand`, and `dispose` methods in a future incremental compile
+
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=dev.anvas.orbitrack.idea
 pluginName=OrbiTrack
-pluginVersion=1.0.4
+pluginVersion=1.0.5
 pluginSinceBuild=251
 pluginUntilBuild=261.*
 

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/api/GitHubModels.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/api/GitHubModels.kt
@@ -113,6 +113,44 @@ data class GhComment(
     @SerialName("updated_at") val updatedAt: String,
 )
 
+/**
+ * A PR inline review comment returned by
+ * GET /repos/{org}/{repo}/pulls/{number}/comments
+ * or the `gh api` equivalent.
+ */
+@Serializable
+data class GhReviewComment(
+    val id: Long,
+    val user: GhUser,
+    val body: String? = null,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+    val path: String = "",
+    val line: Int? = null,
+    @SerialName("original_line") val originalLine: Int? = null,
+    @SerialName("diff_hunk") val diffHunk: String = "",
+    @SerialName("in_reply_to_id") val inReplyToId: Long? = null,
+    @SerialName("pull_request_review_id") val pullRequestReviewId: Long? = null,
+) {
+    fun toOrbiReviewComment(itemId: Long): dev.anvas.orbitrack.idea.model.OrbiReviewComment {
+        val bodyText = body.orEmpty()
+        return dev.anvas.orbitrack.idea.model.OrbiReviewComment(
+            id = id,
+            itemId = itemId,
+            author = user.login,
+            body = bodyText,
+            createdAt = java.time.Instant.parse(createdAt),
+            updatedAt = java.time.Instant.parse(updatedAt),
+            path = path,
+            line = line ?: originalLine,
+            diffHunk = diffHunk,
+            isSuggestion = bodyText.contains("```suggestion", ignoreCase = true),
+            inReplyToId = inReplyToId,
+            reviewId = pullRequestReviewId,
+        )
+    }
+}
+
 @Serializable
 data class GhSearchResult(
     @SerialName("total_count") val totalCount: Int,

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/model/OrbiItem.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/model/OrbiItem.kt
@@ -43,6 +43,25 @@ data class OrbiComment(
     val canEdit: Boolean,
 )
 
+/**
+ * A PR inline review comment (from the "Files changed" tab).
+ * May contain a GitHub code suggestion block (```suggestion).
+ */
+data class OrbiReviewComment(
+    val id: Long,
+    val itemId: Long,          // the PR id
+    val author: String,
+    val body: String,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+    val path: String,          // file path the comment is anchored to
+    val line: Int?,            // target line number (null for file-level comments)
+    val diffHunk: String,      // surrounding diff context sent by GitHub
+    val isSuggestion: Boolean, // body contains a ```suggestion block
+    val inReplyToId: Long?,    // non-null when this is a reply inside a thread
+    val reviewId: Long?,       // pull_request_review_id
+)
+
 @Serializable
 data class TrackedRepo(
     val org: String,

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/services/GhJsonUtils.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/services/GhJsonUtils.kt
@@ -1,0 +1,29 @@
+package dev.anvas.orbitrack.idea.services
+
+/**
+ * Utility functions for processing raw `gh` CLI JSON output.
+ */
+
+/**
+ * `gh api --paginate` emits one JSON array per page with no separator between them,
+ * e.g. `[...][...]`.  This function joins such output into a single, valid JSON array
+ * so that kotlinx.serialization can parse it.
+ *
+ * Handles:
+ *  - Single page: `[...]`  → returned as-is
+ *  - Multi-page: `[...][...]` → `[...,...]`
+ *  - Empty pages: `[][]`   → `[]`
+ *  - Mixed whitespace between arrays
+ *  - Non-array input (single object `{...}`) → returned as-is
+ */
+internal fun normaliseGhPaginatedJson(raw: String): String {
+    val trimmed = raw.trim()
+    if (!trimmed.startsWith("[")) return trimmed   // single object – pass through
+    return trimmed.replace(Regex("""\]\s*\["""), ",")
+        .let { merged ->
+            // `[][...]` or `[...][` edge cases – collapse empty brackets that result in `[,`
+            merged.replace(Regex("""\[,"""), "[")
+                  .replace(Regex(""",]"""), "]")
+        }
+}
+

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/services/OrbiTrackProjectService.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/services/OrbiTrackProjectService.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import dev.anvas.orbitrack.idea.api.GhPullDetail
+import dev.anvas.orbitrack.idea.api.GhReviewComment
 import dev.anvas.orbitrack.idea.cache.CachedFilterState
 import dev.anvas.orbitrack.idea.cache.CachedState
 import dev.anvas.orbitrack.idea.cache.OrbiCacheManager
@@ -12,10 +13,12 @@ import dev.anvas.orbitrack.idea.cache.OrbiCacheManager.Companion.toCached
 import dev.anvas.orbitrack.idea.cache.OrbiCacheManager.Companion.toOrbiItem
 import dev.anvas.orbitrack.idea.model.OrbiComment
 import dev.anvas.orbitrack.idea.model.OrbiItem
+import dev.anvas.orbitrack.idea.model.OrbiReviewComment
 import dev.anvas.orbitrack.idea.model.OrbiTimelineEvent
 import dev.anvas.orbitrack.idea.model.ItemType
 import dev.anvas.orbitrack.idea.model.ItemState
 import dev.anvas.orbitrack.idea.model.TrackedRepo
+import kotlinx.serialization.json.Json
 import kotlinx.coroutines.*
 import java.time.Instant
 
@@ -40,7 +43,11 @@ class OrbiTrackProjectService(private val project: Project) : Disposable {
     private val commentsMap = mutableMapOf<Int, List<OrbiComment>>()
     private val timelineMap = mutableMapOf<Int, List<OrbiTimelineEvent>>()
     private val pullDetailMap = mutableMapOf<Int, GhPullDetail>()
+    private val reviewCommentsMap = mutableMapOf<Int, List<OrbiReviewComment>>()
+    private val reviewCommentsHasMore = mutableSetOf<Int>()
     private var authenticatedUser: String? = null
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
     /** Timestamp of the last successful refresh, used for incremental fetches via Search API. */
     private var lastRefreshTimestamp: Instant? = null
@@ -194,11 +201,14 @@ class OrbiTrackProjectService(private val project: Project) : Disposable {
                 val events = client.getTimeline(item.org, item.repo, item.number)
                 timelineMap[item.number] = events
 
-                // For PRs, reload merge/branch detail
+                // For PRs, reload merge/branch detail and review comments
                 if (freshItem.type == ItemType.PR) {
                     pullDetailMap.remove(item.number)
+                    reviewCommentsMap.remove(item.number)
+                    reviewCommentsHasMore.remove(item.number)
                     // loadPullDetail will enrich the item and notify again
                     loadPullDetail(freshItem, forceReload = true)
+                    loadReviewComments(freshItem)
                 }
 
                 onResult?.invoke(true, null)
@@ -626,6 +636,92 @@ class OrbiTrackProjectService(private val project: Project) : Disposable {
         }
     }
 
+    // ---- PR Review Comments (via gh CLI) ----
+
+    fun getReviewComments(itemNumber: Int): List<OrbiReviewComment> =
+        reviewCommentsMap[itemNumber].orEmpty()
+
+    fun hasMoreReviewComments(itemNumber: Int): Boolean =
+        reviewCommentsHasMore.contains(itemNumber)
+
+    fun hasReviewCommentsCached(itemNumber: Int): Boolean =
+        reviewCommentsMap.containsKey(itemNumber)
+
+    /**
+     * Loads PR inline review comments via `gh api`.
+     *
+     * @param loadAll when true, passes `--paginate` to `gh` to fetch every page;
+     *                otherwise fetches the first 30 comments and marks hasMore when applicable.
+     */
+    fun loadReviewComments(item: OrbiItem, loadAll: Boolean = false) {
+        if (item.type != ItemType.PR) return
+        if (!loadAll && reviewCommentsMap.containsKey(item.number)) return
+        scope.launch {
+            try {
+                val endpoint = "repos/${item.org}/${item.repo}/pulls/${item.number}/comments"
+                val result = if (loadAll) {
+                    runGhCommand("api", endpoint, "--paginate")
+                } else {
+                    runGhCommand("api", "$endpoint?per_page=30&page=1")
+                }
+                if (result.exitCode != 0) {
+                    log.warn("gh api review comments failed (${item.org}/${item.repo}#${item.number}): ${result.stderr}")
+                    return@launch
+                }
+                // gh --paginate emits one JSON array per page concatenated — normalise to one array
+                val rawJson = normaliseGhPaginatedJson(result.stdout)  // see GhJsonUtils.kt
+                val ghComments = json.decodeFromString<List<GhReviewComment>>(rawJson)
+                val mapped = ghComments.map { it.toOrbiReviewComment(item.id) }
+                reviewCommentsMap[item.number] = mapped
+                if (loadAll) {
+                    reviewCommentsHasMore.remove(item.number)
+                } else {
+                    if (mapped.size >= 30) reviewCommentsHasMore.add(item.number)
+                    else reviewCommentsHasMore.remove(item.number)
+                }
+                notifyListeners()
+            } catch (e: Exception) {
+                log.warn("Failed to load review comments for ${item.org}/${item.repo}#${item.number}", e)
+            }
+        }
+    }
+
+    /**
+     * Posts a reply to an existing PR review comment thread via `gh api`.
+     * [body] may contain a ` ```suggestion ` block to propose a code change.
+     */
+    fun replyToReviewComment(
+        item: OrbiItem,
+        inReplyToId: Long,
+        body: String,
+        onResult: (Boolean, String?) -> Unit,
+    ) {
+        scope.launch {
+            try {
+                val endpoint = "repos/${item.org}/${item.repo}/pulls/${item.number}/comments"
+                val result = runGhCommand(
+                    "api", endpoint,
+                    "-X", "POST",
+                    "-f", "body=$body",
+                    "-F", "in_reply_to=$inReplyToId",
+                )
+                if (result.exitCode != 0) {
+                    onResult(false, result.stderr.ifBlank { "gh api error (exit ${result.exitCode})" })
+                    return@launch
+                }
+                // Refresh review comments so the reply appears immediately
+                reviewCommentsMap.remove(item.number)
+                reviewCommentsHasMore.remove(item.number)
+                loadReviewComments(item)
+                onResult(true, null)
+            } catch (e: Exception) {
+                log.warn("Failed to reply to review comment on ${item.org}/${item.repo}#${item.number}", e)
+                onResult(false, e.message)
+            }
+        }
+    }
+
+
     // ---- Checkout branch (via git CLI) ----
 
     fun checkoutBranch(item: OrbiItem, onResult: (Boolean, String?) -> Unit) {
@@ -731,6 +827,23 @@ class OrbiTrackProjectService(private val project: Project) : Disposable {
                     .directory(workDir)
                     .redirectErrorStream(false)
                     .start()
+                val stdout = process.inputStream.bufferedReader().readText()
+                val stderr = process.errorStream.bufferedReader().readText()
+                val exitCode = process.waitFor()
+                GitResult(exitCode, stdout.trim(), stderr.trim())
+            } catch (e: Exception) {
+                GitResult(-1, "", e.message ?: "Unknown error")
+            }
+        }
+
+    /** Runs a `gh` CLI command (no working-directory dependency). */
+    private suspend fun runGhCommand(vararg args: String): GitResult =
+        withContext(Dispatchers.IO) {
+            try {
+                val workDir = project.basePath?.let { java.io.File(it) }
+                val pb = ProcessBuilder("gh", *args).redirectErrorStream(false)
+                if (workDir != null && workDir.exists()) pb.directory(workDir)
+                val process = pb.start()
                 val stdout = process.inputStream.bufferedReader().readText()
                 val stderr = process.errorStream.bufferedReader().readText()
                 val exitCode = process.waitFor()

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/ItemDetailPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/ItemDetailPanel.kt
@@ -38,8 +38,9 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
     /** Callback when user wants to refresh this single item. Receives (item). */
     var onRefreshItem: ((OrbiItem) -> Unit)? = null
 
-    /** Callback when user wants to export issue/PR as a .md file. Receives (item, comments). */
-    var onCreateMdFile: ((OrbiItem, List<OrbiComment>) -> Unit)? = null
+    /** Callback when user wants to export issue/PR as a .md file.
+     *  Receives (item, conversation comments, review comments). */
+    var onCreateMdFile: ((OrbiItem, List<OrbiComment>, List<OrbiReviewComment>) -> Unit)? = null
 
     /** Callback to lazily load all PR review comments (removes the 30-item cap). */
     var onLoadAllReviewComments: ((OrbiItem) -> Unit)? = null
@@ -361,11 +362,11 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
                 }
             })
             add(JButton("Copy LLM Context").apply {
-                addActionListener { copyContext(item, comments) }
+                addActionListener { copyContext(item, comments, reviewComments) }
             })
             add(JButton("\uD83D\uDCC4 Create .md file").apply {
                 toolTipText = "Save issue/PR as a Markdown file in the project root"
-                addActionListener { onCreateMdFile?.invoke(item, comments) }
+                addActionListener { onCreateMdFile?.invoke(item, comments, reviewComments) }
             })
         }
 
@@ -741,7 +742,7 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
         border = JBUI.Borders.empty(2, 6, 2, 6)
     }
 
-    private fun copyContext(item: OrbiItem, comments: List<OrbiComment>) {
+    private fun copyContext(item: OrbiItem, comments: List<OrbiComment>, reviewComments: List<OrbiReviewComment>) {
         val ctx = buildString {
             val t = if (item.type == ItemType.PR) "PR" else "Issue"
             appendLine("## $t: ${item.title} (#${item.number})")
@@ -759,6 +760,29 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
                     appendLine("**@${c.author}** $middot ${c.createdAt}")
                     appendLine(c.body)
                     appendLine("---")
+                }
+            }
+            if (reviewComments.isNotEmpty()) {
+                appendLine()
+                appendLine("### Code Review Comments (${reviewComments.size})")
+                val byPath = reviewComments.groupBy { it.path }
+                for ((path, pathComments) in byPath) {
+                    appendLine()
+                    appendLine("#### `$path`")
+                    for (rc in pathComments) {
+                        appendLine()
+                        val replyTag = if (rc.inReplyToId != null) " ↩ reply" else ""
+                        val suggestionTag = if (rc.isSuggestion) " 💡 suggestion" else ""
+                        val lineTag = rc.line?.let { " · line $it" } ?: ""
+                        appendLine("**@${rc.author}**$lineTag$suggestionTag$replyTag $middot ${rc.createdAt}")
+                        if (rc.diffHunk.isNotBlank()) {
+                            appendLine("```diff")
+                            appendLine(rc.diffHunk)
+                            appendLine("```")
+                        }
+                        appendLine(rc.body)
+                        appendLine("---")
+                    }
                 }
             }
             appendLine()

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/ItemDetailPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/ItemDetailPanel.kt
@@ -9,6 +9,7 @@ import dev.anvas.orbitrack.idea.model.ItemState
 import dev.anvas.orbitrack.idea.model.ItemType
 import dev.anvas.orbitrack.idea.model.OrbiComment
 import dev.anvas.orbitrack.idea.model.OrbiItem
+import dev.anvas.orbitrack.idea.model.OrbiReviewComment
 import dev.anvas.orbitrack.idea.model.OrbiTimelineEvent
 import java.awt.*
 import java.awt.datatransfer.StringSelection
@@ -39,6 +40,13 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
 
     /** Callback when user wants to export issue/PR as a .md file. Receives (item, comments). */
     var onCreateMdFile: ((OrbiItem, List<OrbiComment>) -> Unit)? = null
+
+    /** Callback to lazily load all PR review comments (removes the 30-item cap). */
+    var onLoadAllReviewComments: ((OrbiItem) -> Unit)? = null
+
+    /** Callback to post a reply (possibly with a suggestion) to a review thread.
+     *  Receives (item, inReplyToId, body). */
+    var onReplyToReviewComment: ((OrbiItem, Long, String) -> Unit)? = null
 
     private var currentItem: OrbiItem? = null
     private var isItemLoading: Boolean = false
@@ -130,7 +138,13 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
         repaint()
     }
 
-    fun showItem(item: OrbiItem, comments: List<OrbiComment>, timeline: List<OrbiTimelineEvent> = emptyList()) {
+    fun showItem(
+        item: OrbiItem,
+        comments: List<OrbiComment>,
+        timeline: List<OrbiTimelineEvent> = emptyList(),
+        reviewComments: List<OrbiReviewComment> = emptyList(),
+        hasMoreReviewComments: Boolean = false,
+    ) {
         // Preserve scroll position when refreshing the same item
         val isSameItem = currentItem?.let {
             it.org == item.org && it.repo == item.repo && it.number == item.number
@@ -256,6 +270,58 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
             for (event in timeline) {
                 historyBox.add(makeTimelineEntry(event))
                 historyBox.add(Box.createRigidArea(Dimension(0, 2)))
+            }
+        }
+
+        // --- Code Review (PR review comments with inline suggestions) ---
+        val reviewBox = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            isOpaque = false
+            alignmentX = LEFT_ALIGNMENT
+            border = JBUI.Borders.emptyTop(6)
+        }
+        if (item.type == ItemType.PR) {
+            val totalLabel = when {
+                reviewComments.isEmpty() -> "Code Review (loading\u2026)"
+                hasMoreReviewComments -> "Code Review (${reviewComments.size}+)"
+                else -> "Code Review (${reviewComments.size})"
+            }
+            val reviewHeader = JBLabel(totalLabel).apply {
+                font = font.deriveFont(Font.BOLD, 12f)
+                alignmentX = LEFT_ALIGNMENT
+                border = JBUI.Borders.empty(4, 0)
+            }
+            reviewBox.add(reviewHeader)
+
+            if (reviewComments.isNotEmpty()) {
+                // Group by file path
+                val byPath = reviewComments.groupBy { it.path }
+                for ((path, pathComments) in byPath) {
+                    // File path subheader
+                    val fileLabel = JBLabel("\uD83D\uDCC4 $path").apply {
+                        font = font.deriveFont(Font.ITALIC, font.size2D - 0.5f)
+                        foreground = JBColor(0x0969DA, 0x58A6FF)
+                        alignmentX = LEFT_ALIGNMENT
+                        border = JBUI.Borders.empty(6, 0, 2, 0)
+                    }
+                    reviewBox.add(fileLabel)
+
+                    for (rc in pathComments) {
+                        reviewBox.add(makeReviewCommentCard(item, rc))
+                        reviewBox.add(Box.createRigidArea(Dimension(0, 6)))
+                    }
+                }
+            }
+
+            // "Load all" button shown when there are more pages
+            if (hasMoreReviewComments) {
+                val loadAllBtn = JButton("\u2B07 Load all review comments").apply {
+                    alignmentX = LEFT_ALIGNMENT
+                    toolTipText = "Fetch every review comment (may take a moment for large PRs)"
+                    addActionListener { onLoadAllReviewComments?.invoke(item) }
+                }
+                reviewBox.add(Box.createRigidArea(Dimension(0, 4)))
+                reviewBox.add(loadAllBtn)
             }
         }
 
@@ -411,6 +477,7 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
             border = JBUI.Borders.emptyLeft(4)
             add(bodyPane)
             add(commentsBox)
+            add(reviewBox)
             add(historyBox)
             add(actions)
             add(prActions)
@@ -530,6 +597,139 @@ class ItemDetailPanel : JPanel(BorderLayout()) {
                 })
             }
             add(btn, BorderLayout.SOUTH)
+        }
+    }
+
+    /**
+     * Renders a single PR review comment card.
+     *
+     * Layout:
+     *   ┌──────────────────────────────────────────┐
+     *   │ [💡 Suggestion] @author · date            │ ← header (indented if reply)
+     *   │ <pre> diff hunk </pre>                    │ ← code context
+     *   │ <body markdown>                           │ ← comment text / suggestion block
+     *   │                   [↩ Reply] [↩ Suggest]  │ ← action buttons
+     *   └──────────────────────────────────────────┘
+     */
+    private fun makeReviewCommentCard(item: OrbiItem, rc: OrbiReviewComment): JPanel =
+        JPanel(BorderLayout()).apply {
+            val indent = if (rc.inReplyToId != null) 16 else 0
+            border = BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(
+                    if (rc.isSuggestion) JBColor(0x8250DF, 0xA371F7) else JBColor.border(), 1
+                ),
+                JBUI.Borders.empty(8, 8 + indent, 8, 8)
+            )
+            isOpaque = false
+            alignmentX = LEFT_ALIGNMENT
+            maximumSize = Dimension(Int.MAX_VALUE, Int.MAX_VALUE)
+
+            // ---- Header row ----
+            val dateStr = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(ZoneId.systemDefault())
+                .format(rc.createdAt)
+            val authorUrl = "https://github.com/${rc.author}"
+            val linkColor = colorHex(JBColor(0x0969DA, 0x58A6FF))
+            val suggestionBadge = if (rc.isSuggestion)
+                "<span style='background:#8250df;color:#fff;padding:1px 5px;border-radius:3px;font-size:${nativeFontSize - 2}pt;'>\uD83D\uDCA1 suggestion</span>&nbsp;"
+            else ""
+            val replyIndicator = if (rc.inReplyToId != null) "<span style='color:gray;'>\u21AA reply &nbsp;</span>" else ""
+            val lineInfo = rc.line?.let { " · line $it" } ?: ""
+            val headHtml = "<html><body style=\"font-family:'$nativeFontFamily';font-size:${nativeFontSize - 1}pt;margin:0;padding:0;\">" +
+                "$replyIndicator$suggestionBadge" +
+                "<a href=\"$authorUrl\" style=\"color:$linkColor;font-weight:bold;\">@${esc(rc.author)}</a>" +
+                " $middot $dateStr$lineInfo</body></html>"
+            val head = makeHtmlLabel(headHtml).apply {
+                border = JBUI.Borders.emptyBottom(4)
+            }
+
+            // ---- Diff hunk (monospace pre block) ----
+            val hunkPanel = if (rc.diffHunk.isNotBlank()) {
+                val codeBg = colorHex(JBColor(0xF6F8FA, 0x2D333B))
+                val fg = colorHex(JBColor.foreground())
+                val hunkHtml = "<html><body style='margin:0;padding:0;'>" +
+                    "<pre style='font-family:monospace;font-size:${nativeFontSize - 2}pt;" +
+                    "background:$codeBg;color:$fg;padding:6px;margin:0;'>" +
+                    esc(rc.diffHunk) + "</pre></body></html>"
+                JEditorPane("text/html", hunkHtml).apply {
+                    isEditable = false
+                    isOpaque = false
+                    border = JBUI.Borders.emptyBottom(4)
+                }
+            } else null
+
+            // ---- Comment body (markdown; suggestion block rendered as code) ----
+            val bodyHtml = MarkdownRenderer.toHtml(rc.body)
+            val bodyPane = JEditorPane("text/html", bodyHtml).apply {
+                isEditable = false
+                isOpaque = false
+                border = JBUI.Borders.empty()
+                addHyperlinkListener { e ->
+                    if (e.eventType == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED)
+                        com.intellij.ide.BrowserUtil.browse(e.url.toExternalForm())
+                }
+            }
+
+            // ---- Action buttons ----
+            val btnPanel = JPanel(FlowLayout(FlowLayout.RIGHT, 4, 0)).apply {
+                isOpaque = false
+                // Plain reply
+                add(JButton("\u21A9 Reply").apply {
+                    toolTipText = "Reply to this review thread"
+                    addActionListener {
+                        showReplyDialog(item, rc, suggestionTemplate = false)
+                    }
+                })
+                // Reply with suggestion (only shown when the parent is also a suggestion, or always offer it)
+                add(JButton("\uD83D\uDCA1 Suggest").apply {
+                    toolTipText = "Reply with a code suggestion"
+                    addActionListener {
+                        showReplyDialog(item, rc, suggestionTemplate = true)
+                    }
+                })
+            }
+
+            // ---- Compose ----
+            val centerBox = JPanel().apply {
+                layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                isOpaque = false
+                if (hunkPanel != null) add(hunkPanel)
+                add(bodyPane)
+            }
+            add(head, BorderLayout.NORTH)
+            add(centerBox, BorderLayout.CENTER)
+            add(btnPanel, BorderLayout.SOUTH)
+        }
+
+    private fun showReplyDialog(item: OrbiItem, rc: OrbiReviewComment, suggestionTemplate: Boolean) {
+        val textArea = JTextArea(8, 55).apply {
+            lineWrap = true
+            wrapStyleWord = true
+            if (suggestionTemplate) {
+                // Pre-fill with a suggestion block quoting the last changed line from the diff hunk
+                val lastAddedLine = rc.diffHunk.lines()
+                    .lastOrNull { it.startsWith("+") }
+                    ?.removePrefix("+") ?: ""
+                text = "```suggestion\n$lastAddedLine\n```"
+            }
+        }
+        val scroll = JScrollPane(textArea)
+        val replyToLabel = JBLabel(
+            "<html><b>Replying to @${esc(rc.author)}</b> on <code>${esc(rc.path)}</code>${rc.line?.let { " line $it" } ?: ""}</html>"
+        )
+        val dialogPanel = JPanel(BorderLayout(0, 6)).apply {
+            add(replyToLabel, BorderLayout.NORTH)
+            add(scroll, BorderLayout.CENTER)
+        }
+        val result = JOptionPane.showConfirmDialog(
+            this@ItemDetailPanel,
+            dialogPanel,
+            "Reply to review comment",
+            JOptionPane.OK_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE,
+        )
+        if (result == JOptionPane.OK_OPTION && textArea.text.isNotBlank()) {
+            onReplyToReviewComment?.invoke(item, rc.id, textArea.text)
         }
     }
 

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/OrbiTrackPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/OrbiTrackPanel.kt
@@ -163,6 +163,23 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
                 }
             }
         }
+        onLoadAllReviewComments = { item ->
+            service.loadReviewComments(item, loadAll = true)
+        }
+        onReplyToReviewComment = { item, inReplyToId, body ->
+            service.replyToReviewComment(item, inReplyToId, body) { success, error ->
+                ApplicationManager.getApplication().invokeLater {
+                    if (!success && error != null) {
+                        JOptionPane.showMessageDialog(
+                            this@OrbiTrackPanel,
+                            "Failed to post reply: $error",
+                            "OrbiTrack",
+                            JOptionPane.ERROR_MESSAGE
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private val loadMoreButton = JButton("Load more\u2026").apply {
@@ -217,11 +234,14 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
                     detailPanel.showItem(
                         sel.item,
                         service.getComments(sel.item.number),
-                        service.getTimeline(sel.item.number)
+                        service.getTimeline(sel.item.number),
+                        service.getReviewComments(sel.item.number),
+                        service.hasMoreReviewComments(sel.item.number),
                     )
                     service.loadComments(sel.item)
                     service.loadTimeline(sel.item)
                     service.loadPullDetail(sel.item)
+                    if (sel.item.type == ItemType.PR) service.loadReviewComments(sel.item)
                 } else {
                     detailPanel.showEmpty()
                 }
@@ -293,7 +313,9 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
             detailPanel.showItem(
                 freshItem,
                 svc.getComments(freshItem.number),
-                svc.getTimeline(freshItem.number)
+                svc.getTimeline(freshItem.number),
+                svc.getReviewComments(freshItem.number),
+                svc.hasMoreReviewComments(freshItem.number),
             )
         }
     }

--- a/src/main/kotlin/dev/anvas/orbitrack/idea/ui/OrbiTrackPanel.kt
+++ b/src/main/kotlin/dev/anvas/orbitrack/idea/ui/OrbiTrackPanel.kt
@@ -16,6 +16,7 @@ import com.intellij.util.ui.JBUI
 import dev.anvas.orbitrack.idea.model.ItemType
 import dev.anvas.orbitrack.idea.model.OrbiComment
 import dev.anvas.orbitrack.idea.model.OrbiItem
+import dev.anvas.orbitrack.idea.model.OrbiReviewComment
 import dev.anvas.orbitrack.idea.services.OrbiTrackProjectService
 import java.awt.BorderLayout
 import java.io.File
@@ -137,7 +138,7 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
                 }
             }
         }
-        onCreateMdFile = { item, comments ->
+        onCreateMdFile = { item, comments, reviewComments ->
             val basePath = project.basePath
             if (basePath == null) {
                 JOptionPane.showMessageDialog(
@@ -150,7 +151,7 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
                 val typeStr = item.type.name.lowercase()
                 val filename = "$typeStr-${item.org}-${item.repo}-${item.number}.md"
                 val targetFile = File(basePath, filename)
-                val content = buildMdFileContent(item, comments)
+                val content = buildMdFileContent(item, comments, reviewComments)
 
                 WriteCommandAction.runWriteCommandAction(project) {
                     targetFile.writeText(content)
@@ -383,7 +384,11 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
         return result
     }
 
-    private fun buildMdFileContent(item: OrbiItem, comments: List<OrbiComment>): String {
+    private fun buildMdFileContent(
+        item: OrbiItem,
+        comments: List<OrbiComment>,
+        reviewComments: List<OrbiReviewComment> = emptyList(),
+    ): String {
         val dateFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
             .withZone(ZoneId.systemDefault())
         val typeStr = if (item.type == ItemType.PR) "PR" else "Issue"
@@ -417,6 +422,32 @@ class OrbiTrackPanel(private val project: Project) : JPanel(BorderLayout()), Dis
                     appendLine("### @${c.author} · ${dateFmt.format(c.createdAt)}")
                     appendLine()
                     appendLine(c.body)
+                }
+            }
+            if (reviewComments.isNotEmpty()) {
+                appendLine()
+                appendLine("---")
+                appendLine()
+                appendLine("## Code Review (${reviewComments.size} inline comments)")
+                val byPath = reviewComments.groupBy { it.path }
+                for ((path, pathComments) in byPath) {
+                    appendLine()
+                    appendLine("### `$path`")
+                    for (rc in pathComments) {
+                        appendLine()
+                        val replyTag = if (rc.inReplyToId != null) " ↩ reply" else ""
+                        val suggestionTag = if (rc.isSuggestion) " 💡 suggestion" else ""
+                        val lineTag = rc.line?.let { " · line $it" } ?: ""
+                        appendLine("#### @${rc.author}$lineTag$suggestionTag$replyTag · ${dateFmt.format(rc.createdAt)}")
+                        appendLine()
+                        if (rc.diffHunk.isNotBlank()) {
+                            appendLine("```diff")
+                            appendLine(rc.diffHunk)
+                            appendLine("```")
+                            appendLine()
+                        }
+                        appendLine(rc.body)
+                    }
                 }
             }
         }

--- a/src/test/kotlin/dev/anvas/orbitrack/idea/GhJsonNormalisationTest.kt
+++ b/src/test/kotlin/dev/anvas/orbitrack/idea/GhJsonNormalisationTest.kt
@@ -1,0 +1,121 @@
+package dev.anvas.orbitrack.idea
+
+import dev.anvas.orbitrack.idea.services.normaliseGhPaginatedJson
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the [normaliseGhPaginatedJson] utility function.
+ *
+ * `gh api --paginate` concatenates one JSON array per page without any separator,
+ * producing output like `[{"id":1}][{"id":2}]`.  The helper must collapse this
+ * into a single valid array before kotlinx.serialization can parse it.
+ */
+class GhJsonNormalisationTest {
+
+    // ---- single-page pass-through ----
+
+    @Test
+    fun `single array passes through unchanged`() {
+        val input = """[{"id":1},{"id":2}]"""
+        assertEquals(input, normaliseGhPaginatedJson(input))
+    }
+
+    @Test
+    fun `empty single array passes through unchanged`() {
+        val input = "[]"
+        assertEquals("[]", normaliseGhPaginatedJson(input))
+    }
+
+    @Test
+    fun `single object passes through unchanged`() {
+        val input = """{"id":1}"""
+        assertEquals(input, normaliseGhPaginatedJson(input))
+    }
+
+    // ---- multi-page concatenation ----
+
+    @Test
+    fun `two pages are merged into one array`() {
+        val page1 = """[{"id":1},{"id":2}]"""
+        val page2 = """[{"id":3}]"""
+        val result = normaliseGhPaginatedJson("$page1$page2")
+        assertEquals("""[{"id":1},{"id":2},{"id":3}]""", result)
+    }
+
+    @Test
+    fun `three pages are merged into one array`() {
+        val input = """[{"id":1}][{"id":2}][{"id":3}]"""
+        val result = normaliseGhPaginatedJson(input)
+        assertEquals("""[{"id":1},{"id":2},{"id":3}]""", result)
+    }
+
+    @Test
+    fun `pages separated by newline whitespace are merged`() {
+        val input = "[{\"id\":1}]\n[{\"id\":2}]"
+        val result = normaliseGhPaginatedJson(input)
+        assertEquals("""[{"id":1},{"id":2}]""", result)
+    }
+
+    @Test
+    fun `pages separated by multiple spaces are merged`() {
+        val input = """[{"id":1}]   [{"id":2}]"""
+        val result = normaliseGhPaginatedJson(input)
+        assertEquals("""[{"id":1},{"id":2}]""", result)
+    }
+
+    // ---- empty page handling ----
+
+    @Test
+    fun `empty second page is collapsed gracefully`() {
+        val input = """[{"id":1}][]"""
+        val result = normaliseGhPaginatedJson(input)
+        // Should not produce invalid JSON like [{"id":1},]
+        val trimmed = result.trim()
+        assertValidJsonArray(trimmed)
+    }
+
+    @Test
+    fun `two empty pages produce empty array`() {
+        val input = "[][]"
+        val result = normaliseGhPaginatedJson(input)
+        assertValidJsonArray(result.trim())
+    }
+
+    // ---- leading / trailing whitespace ----
+
+    @Test
+    fun `leading and trailing whitespace is stripped`() {
+        val input = "  [{\"id\":1}]  "
+        val result = normaliseGhPaginatedJson(input)
+        assertEquals("""[{"id":1}]""", result)
+    }
+
+    // ---- round-trip with kotlinx.serialization ----
+
+    @Test
+    fun `merged output can be parsed by kotlinx-serialization`() {
+        val page1 = """[{"id":1,"login":"alice"},{"id":2,"login":"bob"}]"""
+        val page2 = """[{"id":3,"login":"carol"}]"""
+        val merged = normaliseGhPaginatedJson("$page1$page2")
+
+        @kotlinx.serialization.Serializable
+        data class Item(val id: Int, val login: String)
+
+        val items = kotlinx.serialization.json.Json.decodeFromString<List<Item>>(merged)
+        assertEquals(3, items.size)
+        assertEquals("alice", items[0].login)
+        assertEquals("carol", items[2].login)
+    }
+
+    // ---- helpers ----
+
+    /** Very lightweight structural check — not a full JSON parser. */
+    private fun assertValidJsonArray(json: String) {
+        assert(json.startsWith("[")) { "Expected JSON array but got: $json" }
+        assert(json.endsWith("]")) { "Expected JSON array but got: $json" }
+        assert(!json.contains("[,")) { "Invalid leading comma in: $json" }
+        assert(!json.contains(",]")) { "Invalid trailing comma in: $json" }
+    }
+}
+

--- a/src/test/kotlin/dev/anvas/orbitrack/idea/GhReviewCommentTest.kt
+++ b/src/test/kotlin/dev/anvas/orbitrack/idea/GhReviewCommentTest.kt
@@ -1,0 +1,266 @@
+package dev.anvas.orbitrack.idea
+
+import dev.anvas.orbitrack.idea.api.GhReviewComment
+import dev.anvas.orbitrack.idea.api.GhUser
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure unit tests for [GhReviewComment] DTO — JSON deserialization and domain mapping.
+ * No IntelliJ Platform or `gh` CLI required.
+ */
+class GhReviewCommentTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    // ---- JSON deserialization ----
+
+    @Test
+    fun `deserializes minimal review comment`() {
+        val raw = """{
+            "id": 1,
+            "user": {"login": "alice"},
+            "body": "LGTM",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "path": "src/Foo.kt",
+            "diff_hunk": "@@ -1,3 +1,3 @@"
+        }"""
+        val comment = json.decodeFromString<GhReviewComment>(raw)
+        assertEquals(1L, comment.id)
+        assertEquals("alice", comment.user.login)
+        assertEquals("LGTM", comment.body)
+        assertEquals("src/Foo.kt", comment.path)
+        assertEquals("@@ -1,3 +1,3 @@", comment.diffHunk)
+        assertNull(comment.line)
+        assertNull(comment.inReplyToId)
+        assertNull(comment.pullRequestReviewId)
+    }
+
+    @Test
+    fun `deserializes review comment with all optional fields`() {
+        val raw = """{
+            "id": 42,
+            "user": {"login": "bob"},
+            "body": "```suggestion\nfixed\n```",
+            "created_at": "2024-06-15T12:00:00Z",
+            "updated_at": "2024-06-15T12:30:00Z",
+            "path": "lib/Bar.kt",
+            "line": 17,
+            "original_line": 15,
+            "diff_hunk": "@@ -14,6 +14,6 @@",
+            "in_reply_to_id": 7,
+            "pull_request_review_id": 99
+        }"""
+        val comment = json.decodeFromString<GhReviewComment>(raw)
+        assertEquals(42L, comment.id)
+        assertEquals(17, comment.line)
+        assertEquals(15, comment.originalLine)
+        assertEquals(7L, comment.inReplyToId)
+        assertEquals(99L, comment.pullRequestReviewId)
+    }
+
+    @Test
+    fun `deserializes review comment with null body`() {
+        val raw = """{
+            "id": 5,
+            "user": {"login": "carol"},
+            "body": null,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "path": "README.md",
+            "diff_hunk": "@@ -1 +1 @@"
+        }"""
+        val comment = json.decodeFromString<GhReviewComment>(raw)
+        assertNull(comment.body)
+        // mapping converts null to empty string
+        val mapped = comment.toOrbiReviewComment(itemId = 0L)
+        assertEquals("", mapped.body)
+    }
+
+    @Test
+    fun `ignores unknown fields from GitHub API`() {
+        val raw = """{
+            "id": 3,
+            "user": {"login": "dave", "avatar_url": "https://example.com/avatar.png"},
+            "body": "nit",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "path": "main.kt",
+            "diff_hunk": "@@ -1 +1 @@",
+            "url": "https://api.github.com/...",
+            "html_url": "https://github.com/...",
+            "commit_id": "abc123",
+            "position": null,
+            "original_position": 3,
+            "subject_type": "line"
+        }"""
+        val comment = json.decodeFromString<GhReviewComment>(raw)
+        assertEquals(3L, comment.id)
+        assertEquals("nit", comment.body)
+    }
+
+    // ---- toOrbiReviewComment mapping ----
+
+    @Test
+    fun `toOrbiReviewComment maps all fields correctly`() {
+        val gh = GhReviewComment(
+            id = 10L,
+            user = GhUser("eve"),
+            body = "Looks good",
+            createdAt = "2024-03-01T08:00:00Z",
+            updatedAt = "2024-03-01T09:00:00Z",
+            path = "src/Main.kt",
+            line = 42,
+            originalLine = 40,
+            diffHunk = "@@ -40,4 +40,4 @@\n context\n-old\n+new",
+            inReplyToId = null,
+            pullRequestReviewId = 55L,
+        )
+        val mapped = gh.toOrbiReviewComment(itemId = 999L)
+
+        assertEquals(10L, mapped.id)
+        assertEquals(999L, mapped.itemId)
+        assertEquals("eve", mapped.author)
+        assertEquals("Looks good", mapped.body)
+        assertEquals("src/Main.kt", mapped.path)
+        assertEquals(42, mapped.line)
+        assertEquals("@@ -40,4 +40,4 @@\n context\n-old\n+new", mapped.diffHunk)
+        assertFalse(mapped.isSuggestion)
+        assertNull(mapped.inReplyToId)
+        assertEquals(55L, mapped.reviewId)
+    }
+
+    @Test
+    fun `toOrbiReviewComment falls back to originalLine when line is null`() {
+        val gh = GhReviewComment(
+            id = 1L,
+            user = GhUser("frank"),
+            body = "comment",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "a.kt",
+            line = null,
+            originalLine = 7,
+            diffHunk = "",
+        )
+        val mapped = gh.toOrbiReviewComment(0L)
+        assertEquals(7, mapped.line)
+    }
+
+    @Test
+    fun `toOrbiReviewComment has null line when both line fields are null`() {
+        val gh = GhReviewComment(
+            id = 2L,
+            user = GhUser("grace"),
+            body = "",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "b.kt",
+            diffHunk = "",
+        )
+        val mapped = gh.toOrbiReviewComment(0L)
+        assertNull(mapped.line)
+    }
+
+    @Test
+    fun `toOrbiReviewComment sets inReplyToId when present`() {
+        val gh = GhReviewComment(
+            id = 3L,
+            user = GhUser("hank"),
+            body = "agreed",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "c.kt",
+            diffHunk = "",
+            inReplyToId = 88L,
+        )
+        val mapped = gh.toOrbiReviewComment(0L)
+        assertEquals(88L, mapped.inReplyToId)
+    }
+
+    // ---- isSuggestion detection ----
+
+    @Test
+    fun `isSuggestion is true when body contains suggestion fence`() {
+        val gh = GhReviewComment(
+            id = 4L,
+            user = GhUser("ivy"),
+            body = "Here's a fix:\n```suggestion\nval x = 1\n```",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "d.kt",
+            diffHunk = "",
+        )
+        val mapped = gh.toOrbiReviewComment(0L)
+        assertTrue("isSuggestion must be true when body contains ```suggestion", mapped.isSuggestion)
+    }
+
+    @Test
+    fun `isSuggestion is true regardless of case`() {
+        val gh = GhReviewComment(
+            id = 5L,
+            user = GhUser("jack"),
+            body = "```Suggestion\nfixed\n```",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "e.kt",
+            diffHunk = "",
+        )
+        assertTrue(gh.toOrbiReviewComment(0L).isSuggestion)
+    }
+
+    @Test
+    fun `isSuggestion is false for plain comment`() {
+        val gh = GhReviewComment(
+            id = 6L,
+            user = GhUser("kate"),
+            body = "Please rename this variable.",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "f.kt",
+            diffHunk = "",
+        )
+        assertFalse(gh.toOrbiReviewComment(0L).isSuggestion)
+    }
+
+    @Test
+    fun `isSuggestion is false for null body`() {
+        val gh = GhReviewComment(
+            id = 7L,
+            user = GhUser("leo"),
+            body = null,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+            path = "g.kt",
+            diffHunk = "",
+        )
+        assertFalse(gh.toOrbiReviewComment(0L).isSuggestion)
+    }
+
+    // ---- Timestamps ----
+
+    @Test
+    fun `toOrbiReviewComment parses ISO-8601 timestamps`() {
+        val gh = GhReviewComment(
+            id = 8L,
+            user = GhUser("mia"),
+            body = "ts test",
+            createdAt = "2024-07-04T14:30:00Z",
+            updatedAt = "2024-07-04T15:00:00Z",
+            path = "h.kt",
+            diffHunk = "",
+        )
+        val mapped = gh.toOrbiReviewComment(0L)
+        assertEquals(1720103400000L, mapped.createdAt.toEpochMilli())
+        assertEquals(1720105200000L, mapped.updatedAt.toEpochMilli())
+    }
+}
+

--- a/src/test/kotlin/dev/anvas/orbitrack/idea/MdExportReviewCommentsTest.kt
+++ b/src/test/kotlin/dev/anvas/orbitrack/idea/MdExportReviewCommentsTest.kt
@@ -1,0 +1,229 @@
+package dev.anvas.orbitrack.idea
+
+import dev.anvas.orbitrack.idea.model.ItemState
+import dev.anvas.orbitrack.idea.model.ItemType
+import dev.anvas.orbitrack.idea.model.OrbiComment
+import dev.anvas.orbitrack.idea.model.OrbiItem
+import dev.anvas.orbitrack.idea.model.OrbiReviewComment
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Tests that verify the Markdown export content produced by
+ * [OrbiTrackPanel.buildMdFileContent] and the LLM clipboard context include
+ * PR review comments (code suggestions) when present.
+ *
+ * Because [OrbiTrackPanel] is a Swing component that needs an IntelliJ
+ * [Project], we replicate the pure rendering logic here as a standalone
+ * helper and keep the tests free of platform dependencies.
+ */
+class MdExportReviewCommentsTest {
+
+    // ---------- fixtures ----------
+
+    private val dateFmt = java.time.format.DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm")
+        .withZone(java.time.ZoneId.of("UTC"))
+
+    private fun makeItem() = OrbiItem(
+        id = 1L, org = "acme", repo = "app", number = 42,
+        type = ItemType.PR, state = ItemState.OPEN,
+        title = "Add feature X", body = "Body text.",
+        labels = listOf("bug"), assignees = emptyList(),
+        author = "alice", milestone = null, commentCount = 2,
+        createdAt = Instant.parse("2024-03-01T10:00:00Z"),
+        updatedAt = Instant.parse("2024-03-02T12:00:00Z"),
+        url = "https://github.com/acme/app/pull/42",
+    )
+
+    private fun makeReviewComment(
+        id: Long,
+        author: String = "reviewer",
+        body: String = "Looks good",
+        path: String = "src/Main.kt",
+        line: Int? = 10,
+        diffHunk: String = "@@ -8,7 +8,7 @@\n context\n-old\n+new",
+        isSuggestion: Boolean = false,
+        inReplyToId: Long? = null,
+    ) = OrbiReviewComment(
+        id = id, itemId = 1L, author = author, body = body,
+        createdAt = Instant.parse("2024-03-01T11:00:00Z"),
+        updatedAt = Instant.parse("2024-03-01T11:00:00Z"),
+        path = path, line = line, diffHunk = diffHunk,
+        isSuggestion = isSuggestion, inReplyToId = inReplyToId,
+        reviewId = null,
+    )
+
+    private fun makeComment(id: Long, author: String = "bob", body: String = "A comment") =
+        OrbiComment(
+            id = id, itemId = 1L, author = author, body = body,
+            createdAt = Instant.parse("2024-03-01T09:00:00Z"),
+            updatedAt = Instant.parse("2024-03-01T09:00:00Z"),
+            canEdit = false,
+        )
+
+    // ---------- replicated render logic (mirrors OrbiTrackPanel.buildMdFileContent) ----------
+
+    private fun buildMd(
+        item: OrbiItem,
+        comments: List<OrbiComment>,
+        reviewComments: List<OrbiReviewComment>,
+    ): String = buildString {
+        val typeStr = if (item.type == ItemType.PR) "PR" else "Issue"
+        appendLine("# $typeStr #${item.number}: ${item.title}")
+        appendLine()
+        appendLine("**Repo:** ${item.org}/${item.repo}")
+        appendLine("**State:** ${item.state.name.lowercase()}")
+        appendLine("**Author:** @${item.author}")
+        appendLine("**URL:** ${item.url}")
+        appendLine("**Opened:** ${dateFmt.format(item.createdAt)}")
+        appendLine("**Updated:** ${dateFmt.format(item.updatedAt)}")
+        appendLine()
+        appendLine("---")
+        appendLine()
+        appendLine("## Description")
+        appendLine()
+        appendLine(item.body.ifBlank { "*(no description)*" })
+        if (comments.isNotEmpty()) {
+            appendLine()
+            appendLine("---")
+            appendLine()
+            appendLine("## Comments (${comments.size})")
+            for (c in comments) {
+                appendLine()
+                appendLine("### @${c.author} · ${dateFmt.format(c.createdAt)}")
+                appendLine()
+                appendLine(c.body)
+            }
+        }
+        if (reviewComments.isNotEmpty()) {
+            appendLine()
+            appendLine("---")
+            appendLine()
+            appendLine("## Code Review (${reviewComments.size} inline comments)")
+            val byPath = reviewComments.groupBy { it.path }
+            for ((path, pathComments) in byPath) {
+                appendLine()
+                appendLine("### `$path`")
+                for (rc in pathComments) {
+                    appendLine()
+                    val replyTag = if (rc.inReplyToId != null) " ↩ reply" else ""
+                    val suggestionTag = if (rc.isSuggestion) " 💡 suggestion" else ""
+                    val lineTag = rc.line?.let { " · line $it" } ?: ""
+                    appendLine("#### @${rc.author}$lineTag$suggestionTag$replyTag · ${dateFmt.format(rc.createdAt)}")
+                    appendLine()
+                    if (rc.diffHunk.isNotBlank()) {
+                        appendLine("```diff")
+                        appendLine(rc.diffHunk)
+                        appendLine("```")
+                        appendLine()
+                    }
+                    appendLine(rc.body)
+                }
+            }
+        }
+    }
+
+    // ---------- tests ----------
+
+    @Test
+    fun `md export includes Code Review section when review comments present`() {
+        val md = buildMd(makeItem(), emptyList(), listOf(makeReviewComment(1L)))
+        assertTrue("Must contain Code Review header", md.contains("## Code Review"))
+    }
+
+    @Test
+    fun `md export omits Code Review section when no review comments`() {
+        val md = buildMd(makeItem(), emptyList(), emptyList())
+        assertFalse("Must not contain Code Review section for empty list", md.contains("## Code Review"))
+    }
+
+    @Test
+    fun `md export groups review comments by file path`() {
+        val rcs = listOf(
+            makeReviewComment(1L, path = "src/A.kt"),
+            makeReviewComment(2L, path = "src/B.kt"),
+            makeReviewComment(3L, path = "src/A.kt"),
+        )
+        val md = buildMd(makeItem(), emptyList(), rcs)
+        assertTrue(md.contains("`src/A.kt`"))
+        assertTrue(md.contains("`src/B.kt`"))
+        // Both A.kt comments should appear; verify count in header
+        assertTrue("Should show 3 total review comments", md.contains("3 inline comments"))
+    }
+
+    @Test
+    fun `md export includes diff hunk in a diff code fence`() {
+        val rc = makeReviewComment(1L, diffHunk = "@@ -1,3 +1,3 @@\n-old\n+new")
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertTrue("Diff hunk must be inside a diff fence", md.contains("```diff"))
+        assertTrue(md.contains("@@ -1,3 +1,3 @@"))
+        assertTrue(md.contains("-old"))
+        assertTrue(md.contains("+new"))
+    }
+
+    @Test
+    fun `md export marks suggestion comments with emoji tag`() {
+        val rc = makeReviewComment(1L, isSuggestion = true,
+            body = "```suggestion\nval x = 1\n```")
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertTrue("Suggestion tag must appear in header", md.contains("💡 suggestion"))
+    }
+
+    @Test
+    fun `md export marks reply comments with reply indicator`() {
+        val rc = makeReviewComment(1L, inReplyToId = 99L, body = "Thanks!")
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertTrue("Reply indicator must appear in header", md.contains("↩ reply"))
+    }
+
+    @Test
+    fun `md export includes line number when present`() {
+        val rc = makeReviewComment(1L, line = 42)
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertTrue("Line number must appear in review comment header", md.contains("line 42"))
+    }
+
+    @Test
+    fun `md export omits line number when null`() {
+        val rc = makeReviewComment(1L, line = null, diffHunk = "")
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertFalse(md.contains("· line"))
+    }
+
+    @Test
+    fun `md export includes both conversation comments and review comments`() {
+        val comments = listOf(makeComment(1L, body = "Conversation comment"))
+        val rcs = listOf(makeReviewComment(1L, body = "Review comment"))
+        val md = buildMd(makeItem(), comments, rcs)
+        assertTrue(md.contains("## Comments"))
+        assertTrue(md.contains("Conversation comment"))
+        assertTrue(md.contains("## Code Review"))
+        assertTrue(md.contains("Review comment"))
+    }
+
+    @Test
+    fun `md export omits diff fence when diffHunk is blank`() {
+        val rc = makeReviewComment(1L, diffHunk = "")
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertFalse("No diff fence when hunk is blank", md.contains("```diff"))
+    }
+
+    @Test
+    fun `md export includes review comment author`() {
+        val rc = makeReviewComment(1L, author = "carol")
+        val md = buildMd(makeItem(), emptyList(), listOf(rc))
+        assertTrue(md.contains("@carol"))
+    }
+
+    @Test
+    fun `issues without review comments produce valid md without Code Review section`() {
+        val issue = makeItem().copy(type = ItemType.ISSUE)
+        val md = buildMd(issue, listOf(makeComment(1L)), emptyList())
+        assertTrue(md.startsWith("# Issue #42"))
+        assertFalse(md.contains("Code Review"))
+    }
+}
+

--- a/src/test/kotlin/dev/anvas/orbitrack/idea/OrbiReviewCommentModelTest.kt
+++ b/src/test/kotlin/dev/anvas/orbitrack/idea/OrbiReviewCommentModelTest.kt
@@ -1,0 +1,201 @@
+package dev.anvas.orbitrack.idea
+
+import dev.anvas.orbitrack.idea.model.OrbiReviewComment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+/**
+ * Unit tests for the [OrbiReviewComment] domain model.
+ *
+ * These tests verify the data model contract independently of any GitHub API
+ * client or IntelliJ Platform integration.
+ */
+class OrbiReviewCommentModelTest {
+
+    private fun makeComment(
+        id: Long = 1L,
+        itemId: Long = 100L,
+        author: String = "alice",
+        body: String = "LGTM",
+        path: String = "src/Foo.kt",
+        line: Int? = 10,
+        diffHunk: String = "@@ -8,7 +8,7 @@",
+        isSuggestion: Boolean = false,
+        inReplyToId: Long? = null,
+        reviewId: Long? = null,
+    ) = OrbiReviewComment(
+        id = id,
+        itemId = itemId,
+        author = author,
+        body = body,
+        createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2024-01-01T01:00:00Z"),
+        path = path,
+        line = line,
+        diffHunk = diffHunk,
+        isSuggestion = isSuggestion,
+        inReplyToId = inReplyToId,
+        reviewId = reviewId,
+    )
+
+    // ---- Basic construction ----
+
+    @Test
+    fun `can construct a review comment`() {
+        val rc = makeComment()
+        assertNotNull(rc)
+        assertEquals(1L, rc.id)
+        assertEquals("alice", rc.author)
+        assertEquals("src/Foo.kt", rc.path)
+    }
+
+    @Test
+    fun `timestamps are preserved`() {
+        val rc = makeComment()
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), rc.createdAt)
+        assertEquals(Instant.parse("2024-01-01T01:00:00Z"), rc.updatedAt)
+    }
+
+    // ---- isSuggestion flag ----
+
+    @Test
+    fun `isSuggestion false by default`() {
+        val rc = makeComment(isSuggestion = false)
+        assertFalse(rc.isSuggestion)
+    }
+
+    @Test
+    fun `isSuggestion can be explicitly set to true`() {
+        val rc = makeComment(isSuggestion = true)
+        assertTrue(rc.isSuggestion)
+    }
+
+    @Test
+    fun `copy preserves isSuggestion`() {
+        val original = makeComment(isSuggestion = true)
+        val copied = original.copy(author = "bob")
+        assertTrue("copy must preserve isSuggestion", copied.isSuggestion)
+        assertEquals("bob", copied.author)
+    }
+
+    // ---- Thread replies ----
+
+    @Test
+    fun `inReplyToId is null for top-level comment`() {
+        val rc = makeComment(inReplyToId = null)
+        assertNull(rc.inReplyToId)
+    }
+
+    @Test
+    fun `inReplyToId is set for reply`() {
+        val rc = makeComment(inReplyToId = 77L)
+        assertEquals(77L, rc.inReplyToId)
+    }
+
+    @Test
+    fun `top-level and reply can be distinguished`() {
+        val topLevel = makeComment(id = 1L, inReplyToId = null)
+        val reply = makeComment(id = 2L, inReplyToId = 1L)
+        assertNull(topLevel.inReplyToId)
+        assertNotNull(reply.inReplyToId)
+        assertEquals(1L, reply.inReplyToId)
+    }
+
+    // ---- Nullable line ----
+
+    @Test
+    fun `line is preserved when set`() {
+        val rc = makeComment(line = 42)
+        assertEquals(42, rc.line)
+    }
+
+    @Test
+    fun `line is null for file-level comment`() {
+        val rc = makeComment(line = null)
+        assertNull(rc.line)
+    }
+
+    // ---- Equality and identity ----
+
+    @Test
+    fun `two comments with same id and itemId are equal`() {
+        val a = makeComment(id = 5L, itemId = 200L)
+        val b = makeComment(id = 5L, itemId = 200L)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `comments with different ids are not equal`() {
+        val a = makeComment(id = 5L)
+        val b = makeComment(id = 6L)
+        assert(a != b) { "Comments with different ids must not be equal" }
+    }
+
+    // ---- Grouping by path (simulates the UI grouping logic) ----
+
+    @Test
+    fun `comments can be grouped by path`() {
+        val comments = listOf(
+            makeComment(id = 1L, path = "src/A.kt"),
+            makeComment(id = 2L, path = "src/B.kt"),
+            makeComment(id = 3L, path = "src/A.kt"),
+        )
+        val grouped = comments.groupBy { it.path }
+        assertEquals(2, grouped.size)
+        assertEquals(2, grouped["src/A.kt"]?.size)
+        assertEquals(1, grouped["src/B.kt"]?.size)
+    }
+
+    // ---- Suggestion body detection helper (mirrors service logic) ----
+
+    @Test
+    fun `body containing suggestion fence is detected as suggestion`() {
+        val body = "Please apply this fix:\n```suggestion\nval x = corrected\n```"
+        assertTrue(body.contains("```suggestion", ignoreCase = true))
+    }
+
+    @Test
+    fun `plain body is not detected as suggestion`() {
+        val body = "Could you add a comment here?"
+        assertFalse(body.contains("```suggestion", ignoreCase = true))
+    }
+
+    @Test
+    fun `empty body is not detected as suggestion`() {
+        assertFalse("".contains("```suggestion", ignoreCase = true))
+    }
+
+    // ---- Review thread ordering ----
+
+    @Test
+    fun `thread can be reconstructed by inReplyToId chain`() {
+        val root = makeComment(id = 10L, inReplyToId = null)
+        val reply1 = makeComment(id = 11L, inReplyToId = 10L)
+        val reply2 = makeComment(id = 12L, inReplyToId = 10L)
+
+        val thread = listOf(root, reply1, reply2)
+            .sortedBy { it.inReplyToId ?: Long.MIN_VALUE }
+
+        assertEquals(10L, thread.first().id)  // root first
+    }
+
+    @Test
+    fun `hasMoreReviewComments logic — 30 results implies more pages available`() {
+        val comments = (1..30).map { makeComment(id = it.toLong()) }
+        val hasMore = comments.size >= 30
+        assertTrue(hasMore)
+    }
+
+    @Test
+    fun `hasMoreReviewComments logic — fewer than 30 results implies last page`() {
+        val comments = (1..12).map { makeComment(id = it.toLong()) }
+        val hasMore = comments.size >= 30
+        assertFalse(hasMore)
+    }
+}
+


### PR DESCRIPTION
## What

Implements [Show PR inline review comments (with code suggestions) in the detail panel].

Fetches PR review comments (inline code annotations from the "Files changed" tab,
including code suggestion blocks) via `gh api` and displays them in a new
**Code Review** section inside the item detail panel.

## Changes

### New model
- `OrbiReviewComment` — domain model with `path`, `line`, `diffHunk`,
  `isSuggestion`, `inReplyToId`, `reviewId` fields.

### API layer
- `GhReviewComment` DTO (`@Serializable`) matching GitHub's review comment shape.
- `toOrbiReviewComment(itemId)` mapping extension.

### Service
- `GhJsonUtils.kt` — `internal fun normaliseGhPaginatedJson(raw)` collapses
  `gh api --paginate` output (multiple concatenated JSON arrays) into one.
- `loadReviewComments(item, loadAll=false)` in `OrbiTrackProjectService`:
  - First call: `gh api repos/{org}/{repo}/pulls/{number}/comments?per_page=30&page=1`
  - Load all: `gh api ... --paginate`
  - Auto-invalidated on item refresh.
- `replyToReviewComment(item, inReplyToId, body, onResult)`:
  - `gh api ... -X POST -f body=... -F in_reply_to=<id>`
  - Refreshes review comments after posting.
- `runGhCommand()` utility (mirrors `runGitCommand`).

### UI
- `ItemDetailPanel.showItem()` extended with `reviewComments` and
  `hasMoreReviewComments` parameters.
- **Code Review** section (PR-only): comments grouped by file path, diff hunk
  in monospace, suggestion badge, thread-reply indentation.
- **Load all** lazy button.
- Reply dialog with plain / suggestion templates.

### Tests
| File | Coverage |
|------|----------|
| `GhReviewCommentTest` | DTO deserialization, null handling, `isSuggestion` detection, timestamp parsing |
| `GhJsonNormalisationTest` | single page, multi-page, empty pages, whitespace, round-trip with kotlinx |
| `OrbiReviewCommentModelTest` | domain model fields, grouping, thread ordering, hasMore logic |

## How to test

1. Open a repository that has open PRs with review comments.
2. Select any PR — the **Code Review** section appears below Comments.
3. PRs with > 30 review comments show a **Load all** button.
4. Click **Reply** or **Suggest** on any comment card to post a reply.

